### PR TITLE
Fix AppointmentList window height in UI

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -59,7 +59,7 @@
                            <StackPane fx:id="calendarPanelPlaceholder" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
                         </children>
                      </AnchorPane>
-                     <AnchorPane fx:id="paneDashboard" layoutX="10.0" layoutY="10.0" style="-fx-background-color: #ffffff;" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                     <AnchorPane fx:id="paneDashboard" layoutX="10.0" layoutY="10.0" prefHeight="518.0" prefWidth="500.0" style="-fx-background-color: #ffffff;" AnchorPane.bottomAnchor="42.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                         <children>
                            <GridPane prefHeight="75.0" prefWidth="500.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                               <columnConstraints>
@@ -109,7 +109,7 @@
                                  </Label>
                               </children>
                            </GridPane>
-                           <StackPane fx:id="appointmentListPanelPlaceholder" layoutX="20.0" layoutY="75.0" minHeight="400.0" minWidth="500.0" prefHeight="550.0" prefWidth="500.0" style="-fx-background-color: #ffffff;" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="75.0" />
+                           <StackPane fx:id="appointmentListPanelPlaceholder" layoutX="20.0" layoutY="75.0" minHeight="400.0" minWidth="500.0" prefHeight="454.0" prefWidth="500.0" style="-fx-background-color: #ffffff;" AnchorPane.bottomAnchor="31.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="75.0" />
                         </children>
                      </AnchorPane>
                   </children>


### PR DESCRIPTION
Previously there was a small issue whereby the AppointmentList stack pane goes below the status box. 
![image](https://user-images.githubusercontent.com/47942382/98214474-85257980-1f81-11eb-89ca-794d690655a1.png)